### PR TITLE
feat: set up the bare minimum content for eleventy to build

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -1,0 +1,13 @@
+module.exports = function (eleventyConfig) {
+  eleventyConfig.addPassthroughCopy({ 'src/public': '/' });
+  eleventyConfig.addLayoutAlias('default', 'layout.njk');
+
+  return {
+    dir: {
+      input: 'pages',
+      output: 'dist',
+      includes: '../src',
+    },
+    markdownTemplateEngine: 'njk',
+  };
+};

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
     "node": ">=18"
   },
   "scripts": {
-    "start": "eleventy --serve --incremental",
-    "build": "eleventy",
+    "start": "rm -rf dist && eleventy --serve --incremental",
+    "build": "rm -rf dist && eleventy",
     "lint": "echo \"TODO: add support for linting\" && exit 0",
     "test": "echo \"TODO: add support for testing\" && exit 0",
     "update-deps": "echo \"TODO: add support for updating dependencies\" && exit 0"

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
     "node": ">=18"
   },
   "scripts": {
-    "start": "echo \"TODO: add start script\" && exit 0",
-    "build": "echo \"TODO: add build script\" && exit 0",
+    "start": "eleventy --serve --incremental",
+    "build": "eleventy",
     "lint": "echo \"TODO: add support for linting\" && exit 0",
     "test": "echo \"TODO: add support for testing\" && exit 0",
     "update-deps": "echo \"TODO: add support for updating dependencies\" && exit 0"

--- a/pages/index.md
+++ b/pages/index.md
@@ -1,0 +1,9 @@
+---
+title: Home
+description: This is the home page.
+layout: default
+---
+
+# Home Page
+
+This is the home page.

--- a/src/layout.njk
+++ b/src/layout.njk
@@ -1,0 +1,49 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
+    {% block titleAndDescription %}
+    <title>{{ title }}</title>
+    <meta name="description" content="{{ description }}">
+    {% endblock %}
+
+    {# <link rel="icon" href="/favicon.svg" type="image/svg+xml">
+    <link rel="alternate icon" href="/favicon.png" type="image/png">
+    <link rel="mask-icon" href="/favicon.svg">
+
+    <link rel="apple-touch-icon" href="/maskable_icon.png">
+    <link rel="manifest" href="/manifest.json"> #}
+
+    <meta name="color-scheme" content="light dark">
+    <meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)">
+    <meta name="theme-color" content="#f2f2f2" media="(prefers-color-scheme: light)">
+
+    {# <link rel="stylesheet" href="/styles.css"> #}
+  </head>
+  <body>
+    {% block header %}
+      {% include 'partials/header.njk' %}
+    {% endblock %}
+    <main id="main-content">
+      {% block content %}
+        {{ content | safe }}
+      {% endblock %}
+    </main>
+    {% block footer %}{% endblock %}
+
+    <!-- global scripts, should render on every page -->
+
+    <!-- page-specific scripts, should be set within the page template -->
+    {% block scripts %}{% endblock %}
+
+    {# <script type="module">
+      if ('serviceWorker' in navigator) {
+        window.addEventListener('load', () => {
+          navigator.serviceWorker.register('/service-worker.js');
+        });
+      }
+    </script> #}
+  </body>
+</html>

--- a/src/partials/header.njk
+++ b/src/partials/header.njk
@@ -1,0 +1,5 @@
+<header>
+  <nav>
+    <a href="/">Home</a>
+  </nav>
+</header>


### PR DESCRIPTION
## Description

<!-- Add a description of work done here -->
This adds minimal content and configuration for Eleventy to build the site. This includes:

- one page
- one layout
- one partial (or component)
- one file in the `public` folder

The configuration tells Eleventy where to look and where to put the build output, and that's basically it.

## To Validate

<!-- Add steps a reviewer should follow to validate your changes -->

1. Make sure all PR Checks have passed
2. Pull down this branch
3. Run `npm start`
4. Visit the URL prompted in the terminal and confirm that it matches the minimal page you would expect
5. Run `npm run build` and inspect the `dist` folder, confirming it has one `index.html` file with valid HTML and one empty `robots.txt` file
<!-- Add additional validation steps here -->
