### PR TITLE
feat: generate a sitemap

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# set this to the domain of the environment it runs on (https://example.com)
+# or localhost for local development
+BASE_URL=http://localhost:8080

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "devDependencies": {
         "@11ty/eleventy": "^2.0.0",
+        "dotenv": "^16.0.3",
         "stylelint": "^15.2.0",
         "stylelint-config-standard": "^30.0.1"
       },
@@ -1049,6 +1050,15 @@
       },
       "funding": {
         "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz",
+      "integrity": "sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/ee-first": {
@@ -4501,6 +4511,12 @@
         "domelementtype": "^2.2.0",
         "domhandler": "^4.2.0"
       }
+    },
+    "dotenv": {
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz",
+      "integrity": "sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==",
+      "dev": true
     },
     "ee-first": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "devDependencies": {
     "@11ty/eleventy": "^2.0.0",
+    "dotenv": "^16.0.3",
     "stylelint": "^15.2.0",
     "stylelint-config-standard": "^30.0.1"
   }

--- a/pages/404.md
+++ b/pages/404.md
@@ -3,6 +3,7 @@ title: 404 Not Found
 description: The page you requested could not be found.
 layout: default
 permalink: /404.html
+eleventyExcludeFromCollections: true
 ---
 
 # 404 Not Found

--- a/pages/_data/processEnv.js
+++ b/pages/_data/processEnv.js
@@ -1,0 +1,5 @@
+require('dotenv').config();
+
+module.exports = {
+  BASE_URL: process.env.BASE_URL,
+};

--- a/pages/sitemap.njk
+++ b/pages/sitemap.njk
@@ -1,0 +1,13 @@
+---
+permalink: /sitemap.xml
+eleventyExcludeFromCollections: true
+---
+<?xml version="1.0" encoding="utf-8"?>
+<urlset xmlns="https://www.sitemaps.org/schemas/sitemap/0.9">
+  {% for page in collections.all %}
+    <url>
+      <loc>{{ processEnv.BASE_URL }}{{ page.url | url }}</loc>
+      <lastmod>{{ page.date.toISOString() }}</lastmod>
+    </url>
+  {% endfor %}
+</urlset>


### PR DESCRIPTION
## Description

<!-- Add a description of work done here -->
This does the work needed to be able to generate a sitemap from all the pages that aren't excluded from collections.

## To Validate

<!-- Add steps a reviewer should follow to validate your changes -->

1. Make sure all PR Checks have passed
2. Pull down this branch
3. Run `npm run build`
4. Check `dist/sitemap.xml` and confirm that it's a valid sitemap that lists the home page only (the 404 page was removed from collections)
<!-- Add additional validation steps here -->
